### PR TITLE
Raise limit of builds to 20

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,8 +45,8 @@ pipeline {
 
                     if (msg) {
 
-                        if (msg['update']['builds'].size() > 10) {
-                            echo "There are way too many (${msg['update']['builds'].size()} > 10) builds in the update. Skipping..."
+                        if (msg['update']['builds'].size() > 20) {
+                            echo "There are way too many (${msg['update']['builds'].size()} > 20) builds in the update. Skipping..."
                             return
                         }
 


### PR DESCRIPTION
Seems some folks would appreciate installability being run for larger koji builds. I run into an llvm update:

https://bodhi.fedoraproject.org/updates/FEDORA-2024-0568b75b55

Which had 14 builds.