### PR TITLE
Use `dist-git-branch`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,6 +40,10 @@ pipeline {
                     def msg = readJSON text: CI_MESSAGE
 
                     if (msg) {
+                        if (msg['update']['builds'].size() > 20) {
+                            echo "There are way too many (${msg['update']['builds'].size()} > 20) builds in the update. Skipping..."
+                            return
+                        }
 
                         def bodhiId = msg['update']['updateid']
                         currentBuild.displayName = bodhiId

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,25 +1,5 @@
 #!groovy
 
-// koji-build: trigger if the dist tag matches this regex
-def triggerDistTagRegEx = '^f[3-9]{1}[0-9]{1}$'
-
-// If this is a pull request, run these tests and quit
-if (env.CHANGE_ID) {
-    assert 'f42' ==~ triggerDistTagRegEx
-    assert 'f59' ==~ triggerDistTagRegEx
-
-    currentBuild.result = 'SUCCESS'
-    echo('All tests passed!')
-    return
-}
-
-
-def msg
-def artifactId
-def releaseId
-def additionalArtifactIds
-def allTaskIds = [] as Set
-
 pipeline {
 
     agent none
@@ -40,8 +20,9 @@ pipeline {
                        queue: 'osci-pipelines-queue-14'
                    ],
                    checks: [
-                       [field: '$.update.release.dist_tag', expectedValue: '^(f[3-9]{1}[0-9]{1}|eln|epel10.[0-9]+)$'],
-                       [field: '$.update.release.branch', expectedValue: '^(f[3-9]{1}[0-9]{1}|rawhide|eln|epel10)$']
+                       // Get every update except Flatpack and Container
+                       // See the `ID Prefix` of the releases in https://bodhi.fedoraproject.org/releases
+                       [field: '$.update.release.id_prefix', expectedValue: '^(FEDORA|FEDORA-EPEL|FEDORA-EPEL-NEXT)$'],
                    ]
                )
            ]
@@ -56,42 +37,29 @@ pipeline {
         stage('Trigger Testing') {
             steps {
                 script {
-                    msg = readJSON text: CI_MESSAGE
+                    def msg = readJSON text: CI_MESSAGE
 
                     if (msg) {
 
-                        if (msg['update']['builds'].size() > 20) {
-                            echo "There are way too many (${msg['update']['builds'].size()} > 20) builds in the update. Skipping..."
-                            return
-                        }
+                        def bodhiId = msg['update']['updateid']
+                        currentBuild.displayName = bodhiId
+
+                        def allTaskIds = [] as Set
 
                         msg['artifact']['builds'].each { build ->
                             allTaskIds.add(build['task_id'])
                         }
+                        def artifactIds = allTaskIds.collect{ "koji-build:${it}" }.join(',')
 
-                        def testProfile
-                        if (msg['update']['release']['branch'] == 'epel10') {
-                            testProfile = 'epel10'
-                        } else {
-                            testProfile = msg['update']['release']['dist_tag']
-                        }
-
-                        if (allTaskIds) {
-                            allTaskIds.each { taskId ->
-                                artifactId = "koji-build:${taskId}"
-                                additionalArtifactIds = allTaskIds.findAll{ it != taskId }.collect{ "koji-build:${it}" }.join(',')
-
-                                build(
-                                    job: 'fedora-ci/installability-pipeline/master',
-                                    wait: false,
-                                    parameters: [
-                                        string(name: 'ARTIFACT_ID', value: artifactId),
-                                        string(name: 'ADDITIONAL_ARTIFACT_IDS',value: additionalArtifactIds),
-                                        string(name: 'TEST_PROFILE',value: testProfile)
-                                    ]
-                                )
-                            }
-                        }
+                        build(
+                            job: 'fedora-ci/installability-pipeline/master',
+                            wait: false,
+                            parameters: [
+                                string(name: 'BODHI_UPDATE_ID', value: bodhiId),
+                                string(name: 'ARTIFACT_IDS', value: artifactIds),
+                                string(name: 'DIST_GIT_BRANCH', value: msg['update']['release']['branch']),
+                            ]
+                        )
                     }
                 }
             }


### PR DESCRIPTION
Depends on https://github.com/fedora-ci/installability-pipeline/pull/63

This brings together a few changes:
- Various cleanups
- Enable testing for bigger updates, the tests will have combined results for the whole bodhi update
- Enable testing for all branches
- Consolidate the design so that the trigger jobs can later be merged